### PR TITLE
Allow the HTTP adapter to be configured with a timeout value.

### DIFF
--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -36,7 +36,7 @@ module OrientdbClient
                         HttpAdapters::TyphoeusAdapter
                       end
       @instrumenter = options[:instrumenter] || Instrumenters::Noop
-      @http_client = adapter_klass.new
+      @http_client = adapter_klass.new(timeout: options[:timeout])
       @node = Node.new(host: @host, port: @port, http_client: @http_client, client: self)
       @connected = false
       self

--- a/lib/orientdb_client/errors.rb
+++ b/lib/orientdb_client/errors.rb
@@ -20,6 +20,7 @@ module OrientdbClient
   class DistributedRecordLockedException < TransactionException; end
   # Generic DistributedException, generally a more specific error is preferable.
   class DistributedException < ServerError; end
+  class Timeout < ServerError; end
 
   # ClientError: you did something wrong
   class ClientError < OrientdbError; end

--- a/lib/orientdb_client/http_adapters.rb
+++ b/lib/orientdb_client/http_adapters.rb
@@ -5,10 +5,12 @@ module OrientdbClient
     class Base
       attr_accessor :username, :password
 
-      def initialize
+      def initialize(timeout: nil)
         @username = nil
         @password = nil
         @session_id = nil
+        @timeout = timeout
+        after_initialize
       end
 
       def reset_credentials
@@ -19,6 +21,16 @@ module OrientdbClient
 
       def request
         raise NotImplementedError
+      end
+
+      private
+
+      def timed_out!(method, url)
+        raise OrientdbClient::Timeout, "#{method}: #{url}"
+      end
+
+      def after_initialize
+        # noop, override me as necessary
       end
     end
   end

--- a/lib/orientdb_client/http_adapters/typhoeus_adapter.rb
+++ b/lib/orientdb_client/http_adapters/typhoeus_adapter.rb
@@ -6,7 +6,12 @@ module OrientdbClient
 
       def request(method, url, options = {})
         req = prepare_request(method, url, options)
-        run_request(req)
+        response = run_request(req)
+        if response.timed_out?
+          timed_out!(method, url)
+        else
+          return response
+        end
       end
 
       private
@@ -16,6 +21,9 @@ module OrientdbClient
           userpwd: authentication_string(options),
           method: method
         }.merge(options)
+        if timeout = @timeout || options[:timeout]
+          options[:timeout] = timeout
+        end
         Typhoeus::Request.new(url, options)
       end
 

--- a/spec/support/shared_examples_for_http_adapter.rb
+++ b/spec/support/shared_examples_for_http_adapter.rb
@@ -20,6 +20,15 @@ RSpec.shared_examples 'http adapter' do
     end
   end
 
+  describe 'timeout handling' do
+    let(:url) { 'http://localhost:2480/listDatabases' }
+
+    it 'raises a Timeout exception' do
+      stub_request(:get, url).to_timeout
+      expect { adapter.request(:get, url) }.to raise_exception(OrientdbClient::Timeout)
+    end
+  end
+
   describe '#request' do
     describe 'GET' do
       let(:url) { 'http://localhost:2480/listDatabases' }


### PR DESCRIPTION
There are some serious and well-known issues with ruby timeout being unsafe. We can support timeouts without opening ourselves up to these issues by passing the value through to the relevant HTTP client.

I wasn't able to write non-flaky integration specs for this code, so the test coverage isn't great here.