### PR TITLE
Improve adapter error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+* Differentiate between Typhoeus adapter timeouts and connection failures.
+* Prevent Curb errors from bubbling up to gem user; convert some of them to native
+OrientdbClient errors.
+
 ## 0.0.4
 
 * Added support for timeouts.

--- a/lib/orientdb_client/errors.rb
+++ b/lib/orientdb_client/errors.rb
@@ -37,4 +37,10 @@ module OrientdbClient
   class NotFoundError < OrientdbError; end
 
   class NegativeArraySizeException < OrientdbError; end
+
+  # Some adapters, e.g. Curb, have many different errors they may raise, and we don't
+  # want to have to worry about rescuing each individual one (e.g. FTPError), so if
+  # we get an exception from an adapter for which we don't have a clear mapping to a native
+  # OrientdbClient error, just wrap it in HttpAdapterError.
+  class HttpAdapterError < OrientdbError; end
 end

--- a/lib/orientdb_client/http_adapters/curb_adapter.rb
+++ b/lib/orientdb_client/http_adapters/curb_adapter.rb
@@ -10,6 +10,12 @@ module OrientdbClient
         req
       rescue Curl::Err::TimeoutError
         timed_out!(method, url)
+      rescue Curl::Err::ConnectionFailedError, Curl::Err::HostResolutionError
+        raise ConnectionError
+      rescue Curl::Err::MalformedURLError
+        raise ClientError
+      rescue Curl::Err::CurlError
+        raise HttpAdapterError
       end
 
       private

--- a/lib/orientdb_client/http_adapters/typhoeus_adapter.rb
+++ b/lib/orientdb_client/http_adapters/typhoeus_adapter.rb
@@ -7,7 +7,9 @@ module OrientdbClient
       def request(method, url, options = {})
         req = prepare_request(method, url, options)
         response = run_request(req)
-        if response.timed_out?
+        if response.return_message == "Couldn't connect to server".freeze
+          raise ConnectionError
+        elsif response.timed_out?
           timed_out!(method, url)
         else
           return response

--- a/spec/curb_adapter_spec.rb
+++ b/spec/curb_adapter_spec.rb
@@ -5,4 +5,29 @@ RSpec.describe OrientdbClient::HttpAdapters::CurbAdapter do
   it_behaves_like 'http adapter' do
     let(:adapter_klass) { OrientdbClient::HttpAdapters::CurbAdapter }
   end
+
+  describe '#request' do
+    let(:adapter) { OrientdbClient::HttpAdapters::CurbAdapter.new }
+    subject { adapter.request(:get, 'http://localhost/foo') }
+
+    it 'converts Curl::Err::ConnectionFailedError into a ConnectionError' do
+      allow(adapter).to receive(:run_request) { raise Curl::Err::ConnectionFailedError }
+      expect { subject }.to raise_exception(OrientdbClient::ConnectionError)
+    end
+
+    it 'converts Curl::Err::HostResolutionError into a ConnectionError' do
+      allow(adapter).to receive(:run_request) { raise Curl::Err::HostResolutionError }
+      expect { subject }.to raise_exception(OrientdbClient::ConnectionError)
+    end
+
+    it 'converts Curl::Err::MalformedURLError into a ClientError' do
+      allow(adapter).to receive(:run_request) { raise Curl::Err::MalformedURLError }
+      expect { subject }.to raise_exception(OrientdbClient::ClientError)
+    end
+
+    it 'converts other Curl errors into HttpAdapaterError' do
+      allow(adapter).to receive(:run_request) { raise Curl::Err::HTTPFailedError }
+      expect { subject }.to raise_exception(OrientdbClient::HttpAdapterError)
+    end
+  end
 end

--- a/spec/typhoeus_adapter_spec.rb
+++ b/spec/typhoeus_adapter_spec.rb
@@ -5,4 +5,13 @@ RSpec.describe OrientdbClient::HttpAdapters::TyphoeusAdapter do
   it_behaves_like 'http adapter' do
     let(:adapter_klass) { OrientdbClient::HttpAdapters::TyphoeusAdapter }
   end
+
+  describe '#request' do
+    let(:adapter) { OrientdbClient::HttpAdapters::TyphoeusAdapter.new }
+    subject { adapter.request(:get, 'http://localhost/noodbhere') }
+
+    it 'raises a connection failure if it cannot connect' do
+      expect { subject }.to raise_exception(OrientdbClient::ConnectionError)
+    end
+  end
 end


### PR DESCRIPTION
* Differentiate between Typhoeus adapter timeouts and connection failures.
* Prevent Curb errors from bubbling up to gem user; convert some of them to native
OrientdbClient errors.