### PR TITLE
Ensure db creation conflict error messages are correctly handled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* Correctly handle error message for database creation conflict exceptions.
+
 ## 0.0.5
 
 * Differentiate between Typhoeus adapter timeouts and connection failures.

--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -365,7 +365,7 @@ module OrientdbClient
       code = response.response_code
       body = response.body
       if (body.match(/Database.*already exists/))
-        raise ConflictError.new(e.message, code, body)
+        raise ConflictError.new('Database already exists', code, body)
       elsif (body.match(/NegativeArraySizeException/))
         raise NegativeArraySizeException.new(e.message, code, body)
       else
@@ -379,7 +379,7 @@ module OrientdbClient
       [matches[1], matches[2]]
     rescue => e
       if (response.body.match(/Database.*already exists/))
-        raise ConflictError.new(e.message, response.response_code, response.body)
+        raise ConflictError.new('Database already exists', response.response_code, response.body)
       elsif (response.body.match(/NegativeArraySizeException/))
         raise NegativeArraySizeException.new(e.message, response.response_code, response.body)
       else

--- a/spec/orientdb_client_spec.rb
+++ b/spec/orientdb_client_spec.rb
@@ -97,12 +97,22 @@ RSpec.describe OrientdbClient do
         end
 
         context 'with existing database' do
-          it 'creates a database' do
+          it 'raises a ConflictError' do
             client.create_database(temp_db_name, 'plocal', 'document')
             expect(client.database_exists?(temp_db_name)).to be true
             expect do
               client.create_database(temp_db_name, 'plocal', 'document')
             end.to raise_exception(OrientdbClient::ConflictError)
+          end
+
+          it 'extracts the right conflict error message' do
+            client.create_database(temp_db_name, 'plocal', 'document')
+            expect(client.database_exists?(temp_db_name)).to be true
+            begin
+              client.create_database(temp_db_name, 'plocal', 'document')
+            rescue => e
+              expect(e.message).to eql('Database already exists')
+            end
           end
         end
 


### PR DESCRIPTION
Before, we would raise the exception with the message from NoMethodError, which was incorrect.