### PR TITLE
Fix negative array exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Master
 
 * Correctly handle error message for database creation conflict exceptions.
+* Ensure `NegativeArraySizeException`s are correctly converted to `NotFoundError`s across all supported versions of Orientdb.
+* Ensure "database already exists" errors messages are consistent across all supported versions of Orientdb.
 
 ## 0.0.5
 

--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -352,6 +352,10 @@ module OrientdbClient
         raise DistributedRecordLockedException.new("#{odb_error_class}: #{odb_error_message}", code, body)
       when /OSerializationException/
         raise SerializationException.new("#{odb_error_class}: #{odb_error_message}", code, body)
+      when /NegativeArraySizeException/
+        raise NegativeArraySizeException.new("#{odb_error_class}: #{odb_error_message}", code, body)
+      else
+        raise ServerError.new("Unparseable Orientdb server error", code, body)
       end
     end
 

--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -344,10 +344,12 @@ module OrientdbClient
       when /ODatabaseException/
         if odb_error_message.match(/already exists/)
           klass = ConflictError
+          message = 'Database already exists'
         else
           klass = ServerError
+          message = "#{odb_error_class}: #{odb_error_message}"
         end
-        raise klass.new("#{odb_error_class}: #{odb_error_message}", code, body)
+        raise klass.new(message, code, body)
       when /ODistributedRecordLockedException/
         raise DistributedRecordLockedException.new("#{odb_error_class}: #{odb_error_message}", code, body)
       when /OSerializationException/


### PR DESCRIPTION
* Ensure `NegativeArraySizeException`s are correctly converted to `NotFoundError`s across all supported versions of Orientdb.
* Ensure "database already exists" errors messages are consistent across all supported versions of Orientdb.