### PR TITLE
Delete `safely_instrument` code since ActiveSupport already does this.

### DIFF
--- a/lib/orientdb_client/instrumenters/memory.rb
+++ b/lib/orientdb_client/instrumenters/memory.rb
@@ -12,14 +12,16 @@ module OrientdbClient
       end
 
       def instrument(name, payload = {})
-        result = if block_given?
-          yield payload
-        else
-          nil
+        result = nil
+        begin
+          result = yield payload
+        rescue Exception => e
+          payload[:exception] = [e.class.name, e.message]
+          raise e
+        ensure
+          @events << Event.new(name, payload, result)
+          result
         end
-
-        @events << Event.new(name, payload, result)
-        result
       end
     end
   end

--- a/spec/orientdb_client_spec.rb
+++ b/spec/orientdb_client_spec.rb
@@ -753,7 +753,7 @@ RSpec.describe OrientdbClient do
           client.get_class('OUser')
         rescue
         ensure
-          expect(memory_instrumenter.events.last.payload[:error]).to eq('RuntimeError')
+          expect(memory_instrumenter.events.last.payload[:exception]).to eq(['RuntimeError', 'err'])
         end
       end
 
@@ -776,7 +776,8 @@ RSpec.describe OrientdbClient do
           client.command('insert into OUser CONTENT ' + Oj.dump({a:1}))
         rescue
         ensure
-          expect(memory_instrumenter.events.last.payload[:error]).to eq('OrientdbClient::SerializationException')
+          exception_klass = memory_instrumenter.events.last.payload[:exception].first
+          expect(exception_klass).to eq('OrientdbClient::SerializationException')
         end
       end
     end


### PR DESCRIPTION
Somehow when I wrote this code, I missed the fact that ActiveSupport will already do this for you, basically the only difference is that AS stores the exception class name and message in an `exception` field vs. I was storing the class name only in a field called `error`.