### PR TITLE
Fix as5 test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1
   - 2.2
+  - 2.3.1
 script: bundle exec rspec --tag ~'type:integration'
 matrix:
   include:
@@ -9,3 +10,5 @@ matrix:
       gemfile: Gemfiles/Gemfile.as3.2
     - rvm: 2.2
       gemfile: Gemfiles/Gemfile.as4.0
+    - rvm: 2.3.1
+      gemfile: Gemfiles/Gemfile.as5.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in orientdb_client.gemspec
 gemspec
 
-gem 'activesupport', '> 3.2', require: false
-
 group :test do
+  gem 'activesupport', '~> 4.0', require: false
   gem 'curb', '~> 0.8'
 end

--- a/Gemfiles/Gemfile.as3.2
+++ b/Gemfiles/Gemfile.as3.2
@@ -1,9 +1,8 @@
 source "https://rubygems.org"
 
-gem 'activesupport', '~> 3.2', require: false
-
 group :test do
   gem 'curb', '~> 0.8'
+  gem 'activesupport', '~> 3.2', require: false
 end
 
 gemspec :path => "../"

--- a/Gemfiles/Gemfile.as4.0
+++ b/Gemfiles/Gemfile.as4.0
@@ -1,9 +1,8 @@
 source "https://rubygems.org"
 
-gem 'activesupport', '~> 4.0', require: false
-
 group :test do
   gem 'curb', '~> 0.8'
+  gem 'activesupport', '~> 4.0', require: false
 end
 
 gemspec :path => "../"

--- a/Gemfiles/Gemfile.as5.0
+++ b/Gemfiles/Gemfile.as5.0
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+group :test do
+  gem 'curb', '~> 0.8'
+  gem 'activesupport', '~> 5.0', require: false
+end
+
+gemspec :path => "../"


### PR DESCRIPTION
`gem 'activesupport', '> 3.2', require: false` in `Gemfile` caused a failure when trying to install active support 5.0.0.1 with ruby version < 2.2.2, breaking the travis build.

This can be fixed by explicitly testing ruby 2.3.1 with activesupport 5 (which is a good thing to do anyway) and also specifying activesupport ~>4.0 in the default Gemfile. AFAICT this will not in any way hinder the ability of applications to use the gem with different versions of active support (as it still isn't specified in the gemspec anywhere).