### PR TITLE
Fix keyword argument syntax that caused "circular argument" warning.

### DIFF
--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -140,7 +140,7 @@ module OrientdbClient
     attr_reader :database
     attr_writer :debug
 
-    def initialize(host:, port:, http_client: http_client, client: client)
+    def initialize(host:, port:, http_client:, client:)
       @host = host
       @port = port
       @http_client = http_client


### PR DESCRIPTION
The previous syntax resulted in warnings like "orientdb_client.rb:143: warning: circular argument reference - client".