### PR TITLE
Normalizer for Skylight integration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ gemspec
 group :test do
   gem 'activesupport', '~> 4.0', require: false
   gem 'curb', '~> 0.8'
+  gem 'skylight', '~> 0.10'
 end

--- a/Gemfiles/Gemfile.as3.2
+++ b/Gemfiles/Gemfile.as3.2
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem 'curb', '~> 0.8'
   gem 'activesupport', '~> 3.2', require: false
+  gem 'skylight', '~> 0.10'
 end
 
 gemspec :path => "../"

--- a/Gemfiles/Gemfile.as4.0
+++ b/Gemfiles/Gemfile.as4.0
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem 'curb', '~> 0.8'
   gem 'activesupport', '~> 4.0', require: false
+  gem 'skylight', '~> 0.10'
 end
 
 gemspec :path => "../"

--- a/Gemfiles/Gemfile.as5.0
+++ b/Gemfiles/Gemfile.as5.0
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test do
   gem 'curb', '~> 0.8'
   gem 'activesupport', '~> 5.0', require: false
+  gem 'skylight', '~> 0.10'
 end
 
 gemspec :path => "../"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -20,3 +20,20 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+## Other Licenses
+
+### Ruby on Rails
+
+Copyright (c) 2005-2016 David Heinemeier Hansson
+
+Released under the MIT License.
+
+Original source at https://github.com/rails/rails.
+
+### Skylight
+
+Copyright (c) 2013-2016 Tilde, Inc.
+
+Original source at https://github.com/skylightio/skylight-ruby

--- a/lib/orientdb_client/integration/skylight_normalizer.rb
+++ b/lib/orientdb_client/integration/skylight_normalizer.rb
@@ -1,0 +1,34 @@
+require 'skylight'
+require 'uri'
+
+module Skylight
+  module Normalizers
+    module OrientdbClient
+      class Query < Normalizer
+        register "request.orientdb_client"
+
+        CAT = "db.orientdb.query".freeze
+        QUERY_REGEX = /\/([^\/]+)/
+        SUPPORTED_QUERY_TYPES = ["query".freeze, "command".freeze]
+
+        def normalize(trace, name, payload)
+          url = payload[:url]
+          query_type = nil
+          begin
+            uri = URI.parse(url)
+            match = uri.path.match(QUERY_REGEX)
+            if match
+              query_type = match[1]
+            end
+          rescue URI::Error
+            return :skip
+          end
+
+          return :skip unless SUPPORTED_QUERY_TYPES.include?(query_type)
+
+          [ CAT, "orientdb: #{query_type}", nil ]
+        end
+      end
+    end
+  end
+end

--- a/spec/skylight_normalizer_spec.rb
+++ b/spec/skylight_normalizer_spec.rb
@@ -1,0 +1,84 @@
+# encoding: UTF-8
+
+require 'spec_helper'
+require 'orientdb_client/integration/skylight_normalizer'
+
+RSpec.describe Skylight::Normalizers::OrientdbClient::Query do
+
+  let(:n) { Skylight::Normalizers::OrientdbClient::Query.new({}) }
+  let(:name) { 'odb_query' }
+
+  it 'normalizes a graph query' do
+    name, title, desc = n.normalize(trace, name, url: 'http://localhost:2480/query/graphdb/sql/select+%2A+from+Post+order+by+%40rid+desc+limit+1')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: query')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes a graph query without a title' do
+    name, title, desc = n.normalize(trace, nil, url: 'http://localhost:2480/query/graphdb/sql/select+%2A+from+Post+order+by+%40rid+desc+limit+1')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: query')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes a graph query with multibyte characaters' do
+    name, title, desc = n.normalize(trace, nil, url: 'http://localhost:2480/query/graphdb/sql/select+%2A+from+Post+where+name+%3D+%22%F0%9D%92%9C+FROM+z%C3%B8mg+%C3%A5%22')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: query')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes a graph update with JSON in URL' do
+    name, title, desc = n.normalize(trace, name, url: 'http://localhost:2480/command/graphdb/sql/update+%2311%3A2+set+category_list%3D%5B%22sports%22%2C+%22gaming%22%2C+%22music%22%5D')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: command')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes property creation commands' do
+    name, title, desc = n.normalize(trace, name, url: 'http://localhost:2480/command/graphdb/sql/CREATE+PROPERTY+Post.id+string')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: command')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes property alter commands' do
+    name, title, desc = n.normalize(trace, name, url: 'http://localhost:2480/command/graphdb/sql/ALTER+PROPERTY+Post.exists+type+integer')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: command')
+    expect(desc).to be_nil
+  end
+
+  it 'normalizes class creation commands' do
+    name, title, desc = n.normalize(trace, name, url: 'http://localhost:2480/command/graphdb/sql/CREATE+CLASS+Post')
+    expect(name).to eql('db.orientdb.query')
+    expect(title).to eql('orientdb: command')
+    expect(desc).to be_nil
+  end
+
+  it 'skips connect queries' do
+    name, * = n.normalize(trace, name, url: 'http://localhost:2480/connect/graphdb')
+    expect(name).to eql(:skip)
+  end
+
+  it 'skips disconnect queries' do
+    name, * = n.normalize(trace, name, url: 'http://localhost:2480/disconnect')
+    expect(name).to eql(:skip)
+  end
+
+  it 'skips listDatabase queries' do
+    name, * = n.normalize(trace, name, url: 'http://localhost:2480/listDatabases')
+    expect(name).to eql(:skip)
+  end
+
+  it 'skips database creation' do
+    name, * = n.normalize(trace, name, url: 'http://localhost:2480/database/foobaz/plocal/graph')
+    expect(name).to eql(:skip)
+  end
+
+  it 'skips unknown queries' do
+    name, * = n.normalize(trace, name, url: 'http://localhost:2480/cluster/unknownop?x=y')
+    expect(name).to eql(:skip)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,6 +39,11 @@ ensure
   end
 end
 
+# Require support files
+Dir[File.expand_path('../support/*.rb', __FILE__)].each do |f|
+  require "support/#{File.basename(f, ".rb")}"
+end
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -67,6 +72,8 @@ RSpec.configure do |config|
   config.profile_examples = 10
   config.order = :random
   Kernel.srand config.seed
+
+  config.include SpecHelper
 
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.

--- a/spec/support/skylight_tracing.rb
+++ b/spec/support/skylight_tracing.rb
@@ -1,0 +1,15 @@
+# From Skylight spec/support/tracing.rb
+
+module SpecHelper
+  class MockTrace
+    attr_accessor :endpoint
+
+    def initialize
+      @endpoint = "Rack"
+    end
+  end
+
+  def trace
+    @trace ||= MockTrace.new
+  end
+end


### PR DESCRIPTION
Skylight (skylight.io) is a rails application monitoring service, which can easily instrument code that integrates with `ActiveSupport::Notifications`.

For now we will just subscribe to the `request.orientdb_client` event, which is of greatest interest, as it most closely represents OrientDB query time.

Ideally we would parse/lex the URL as Skylight does for sql queries, so that greater information would be available in the `description`, and also so we could ignore things like property creation and alteration, but I think this would be a) very difficult to get right, without a large sample of live OrientDB queries and/or a deep knowledge of its query language, which I lack; and b) probably fairly resource intensive, since we'd likely have to do a bunch of regex'ing, which I think would add undue overhead (bad cost/benefit ratio).
