### PR TITLE
Add support for OrientDB 2.2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Goals:
 * fine-grained handling of Orientdb errors, via rich set of ruby exceptions
 
 Tested on:
+* 2.2
 * 2.1.10
 * 2.1.9
 * 2.1.5

--- a/lib/orientdb_client.rb
+++ b/lib/orientdb_client.rb
@@ -276,6 +276,8 @@ module OrientdbClient
         raise ConnectionError.new("No server at #{@host}:#{@port}", 0, nil)
       when 200, 201, 204
         return response
+      when 400
+        translate_error(response)
       when 401
         raise UnauthorizedError.new('Unauthorized', response.response_code, response.body)
       when 404
@@ -307,8 +309,8 @@ module OrientdbClient
       code = response.response_code
       body = response.body
       case odb_error_class
-      when /OCommandSQLParsingException/
-        raise ClientError.new("#{odb_error_class}: #{odb_error_message}", code, body)
+      when /OCommandSQLParsingException/, "Error parsing query", "Error on parsing command"
+        raise ParsingError.new("#{odb_error_class}: #{odb_error_message}", code, body)
       when /OQueryParsingException/
         raise ClientError.new("#{odb_error_class}: #{odb_error_message}", code, body)
       when /OCommandExecutorNotFoundException/

--- a/lib/orientdb_client/errors.rb
+++ b/lib/orientdb_client/errors.rb
@@ -28,6 +28,7 @@ module OrientdbClient
   class IllegalArgumentException < ClientError; end
   class CommandExecutionException < ClientError; end
   class SerializationException < ClientError; end
+  class ParsingError < ClientError; end
 
   # ConflictError: you tried to create something that already exists
   class ConflictError < ClientError; end

--- a/spec/orientdb_client_spec.rb
+++ b/spec/orientdb_client_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe OrientdbClient do
 
         context 'with invalid query' do
           it 'raises ClientError' do
-            expect { client.query('select * crumb') }.to raise_exception(OrientdbClient::ClientError, /OCommandSQLParsingException/)
+            expect { client.query('select * crumb') }.to raise_exception(OrientdbClient::ParsingError)
           end
         end
         
@@ -255,7 +255,7 @@ RSpec.describe OrientdbClient do
 
         context 'with invalid query' do
           it 'returns result' do
-            expect { client.command('select * crumb') }.to raise_exception(OrientdbClient::ClientError, /OCommandSQLParsingException/)
+            expect { client.command('select * crumb') }.to raise_exception(OrientdbClient::ParsingError)
           end
         end
       end
@@ -511,7 +511,7 @@ RSpec.describe OrientdbClient do
         it 'raises exception on creation of classes that extend nothing' do
           expect do
             client.create_class(class_name, extends: 'VJk')
-          end.to raise_exception(OrientdbClient::ClientError, /OCommandSQLParsingException/)
+          end.to raise_exception(OrientdbClient::ParsingError)
         end
 
         describe 'with block' do


### PR DESCRIPTION
2.2 appears to make a few changes that affect error handling, namely:

* 400 HTTP codes are returned for malformed/invalid queries and commands
* for these requests, a java-style error class is no longer returned in the response

In order to support this while not breaking backwards compatibility, we can introduce a new error class, `ParsingError` that inherits from `ClientError`. Older clients will continue to work, and anyone conditionally handling `ClientError`s by examining the error message and looking for a string like "OCommandSQLParsingException" can continue to do so, or alternatively rescue `ParsingError`.

People using OrientDB >= 2.2 should not expect that these requests will have "OCommandSQLParsingException" in the error message/response body.
